### PR TITLE
Add Quantum support for Grizzly release to openstack-status

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 name = openstack-utils
 version = 2013.1
-release = 7
+release = 8
 
 all:
 	mkdir ${name}-${version}-${release}

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,7 @@
+2013.1-8 23-05-2013
+  openstack-status:
+    print out all quantum services and update for grizzly
+
 2013.1-7 24-04-2013
   openstack-demo-install:
     fix swift init loop in grizzly

--- a/utils/openstack-status
+++ b/utils/openstack-status
@@ -137,15 +137,7 @@ fi
 
 if test "$quantum"; then
   printf "== Quantum services ==\n"
-  # TODO: Update for Folsom which has plugin ini files in a different location
-  if grep -q '^provider = quantum.plugins.linuxbridge' /etc/quantum/plugins.ini 2>/dev/null; then
-    quantum_plugin=quantum-linuxbridge-agent
-  fi
-  if grep -q '^provider = quantum.plugins.openvswitch' /etc/quantum/plugins.ini 2>/dev/null; then
-    quantum_plugin=quantum-openvswitch-agent
-    quantum_support=openvswitch
-  fi
-  for svc in quantum-server $quantum_plugin $quantum_support; do check_svc "$svc"; done
+  for svc in quantum-server quantum-dhcp-agent quantum-l3-agent quantum-linuxbridge-agent quantum-openvswitch-agent openvswitch; do check_svc "$svc"; done
 fi
 
 if test "$swift"; then


### PR DESCRIPTION
Code was previously present to check quantum status but it
was not compatible with Grizzly.  This patch drops the feature
of a less verbose output of Quantum because /etc/quantum is typically
700 root root requiring the script to run under sudo.

Signed-off-by: Steven Dake sdake@redhat.com
