### PR TITLE
openstack-status: New services to monitor

### DIFF
--- a/utils/openstack-status
+++ b/utils/openstack-status
@@ -150,7 +150,7 @@ if test "$neutron"; then
     check_svc "$neutron-$agent-agent"
   done
   # Optional agents
-  for agent in openvswitch linuxbridge ryu nec mlnx; do
+  for agent in openvswitch linuxbridge ryu nec mlnx metering; do
     service_installed $neutron-$agent-agent &&
     check_svc "$neutron-$agent-agent"
   done


### PR DESCRIPTION
These changes add support for monitoring openstack-ceilometer-notification and neutron-metering-agent.

This fixes https://bugzilla.redhat.com/show_bug.cgi?id=1096054
