### PR TITLE
Skip neutron cleanup scripts for openstack-service utility

### DIFF
--- a/utils/openstack-service
+++ b/utils/openstack-service
@@ -66,7 +66,7 @@ enabled_openstack_services() {
   local svcprefix=$1
 
   enabled_services |
-    egrep '^(openstack|neutron|quantum)' |
+    egrep '^(openstack|neutron|quantum)' | grep -v "neutron-.*-cleanup" |
     ( [ "$svcprefix" ] && egrep "^(openstack-)?${svcprefix}" || cat )
 }
 


### PR DESCRIPTION
openstack-service restart causes neutron-ovs-cleanup to execute because
it's enabled on most of runlevels. This is not required since it
destroys tap devices for virtual networks.
