### PR TITLE
Adds status check for neutron-lbaasv2-agent

### DIFF
--- a/utils/openstack-status
+++ b/utils/openstack-status
@@ -168,7 +168,7 @@ if test "$neutron"; then
   printf "== $neutron services ==\n"
   for svc in $neutron-server; do check_svc "$svc"; done
   # Default agents
-  for agent in dhcp l3 metadata lbaas; do
+  for agent in dhcp l3 metadata lbaas lbaasv2; do
     service_installed $neutron-$agent-agent &&
     check_svc "$neutron-$agent-agent"
   done


### PR DESCRIPTION
The status check for neutron-lbaasv2-agent should be included in
openstack-status.

Bug: https://bugzilla.redhat.com/show_bug.cgi?id=1238527