### PR TITLE
keystone command is no longer part of openstack

### DIFF
--- a/utils/openstack-status
+++ b/utils/openstack-status
@@ -264,7 +264,7 @@ if test "$keystone"; then
     echo "Warning keystonerc not sourced" >&2
   else
     keystonerc=1
-    keystone user-list
+    openstack user list
   fi
 fi
 


### PR DESCRIPTION
replace with openstack user list
Fixes https://github.com/redhat-openstack/openstack-utils/issues/23

Resolves:  rhbz#1360875